### PR TITLE
Only sync the LEDs, if there is a change

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -6,6 +6,7 @@
 
 KeyboardioScanner Model01::leftHand(0);
 KeyboardioScanner Model01::rightHand(3);
+bool Model01::isLEDChanged;
 
 static constexpr uint8_t key_led_map[4][16] = {
   {3,4,11,12,19,20,26,27,     36,37,43,44,51,52,59,60},
@@ -62,8 +63,14 @@ void Model01::setup(void) {
 
 void Model01::led_set_crgb_at(uint8_t i, cRGB crgb) {
     if(i<32) {
+        cRGB oldColor = led_get_crgb_at(i);
+        isLEDChanged |= !(oldColor.r == crgb.r && oldColor.g == crgb.g && oldColor.b == crgb.b);
+
         leftHand.ledData.leds[i] = crgb;
     } else if (i<64) {
+        cRGB oldColor = led_get_crgb_at(i);
+        isLEDChanged |= !(oldColor.r == crgb.r && oldColor.g == crgb.g && oldColor.b == crgb.b);
+
         rightHand.ledData.leds[i-32] = crgb;
     } else {
         // TODO how do we want to handle debugging assertions about crazy user
@@ -86,8 +93,8 @@ cRGB Model01::led_get_crgb_at(uint8_t i) {
 }
 
 void Model01::led_sync() {
-    leftHand.sendLEDData();
-    rightHand.sendLEDData();
+    if (!isLEDChanged)
+        return;
 
     leftHand.sendLEDData();
     rightHand.sendLEDData();
@@ -98,6 +105,10 @@ void Model01::led_sync() {
     leftHand.sendLEDData();
     rightHand.sendLEDData();
 
+    leftHand.sendLEDData();
+    rightHand.sendLEDData();
+
+    isLEDChanged = false;
 }
 
 boolean Model01::led_power_fault() {

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -38,6 +38,7 @@ class Model01 {
     keydata_t previousRightHandState;
 
   private:
+    static bool isLEDChanged;
     static KeyboardioScanner leftHand;
     static KeyboardioScanner rightHand;
 };


### PR DESCRIPTION
To further improve the LED performance, sync only when there is a change. We do this by tracking when change happens, assuming everyone uses the provided accessors.

While we do a bit of extra work each cycle to do the tracking, that pales in comparison to what we gain by not having to transfer data needlessly.