### PR TITLE
Drop the layer save/load methods

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -1,8 +1,5 @@
 #include <Kaleidoscope.h>
 #include <avr/wdt.h>
-#include <EEPROM.h>
-
-#define EEPROM_LAYER_LOCATION 0
 
 KeyboardioScanner Model01::leftHand(0);
 KeyboardioScanner Model01::rightHand(3);
@@ -184,18 +181,6 @@ void Model01::reboot_bootloader() {
 
     while (1) {} // This infinite loop ensures nothing else
     // happens before the watchdog reboots us
-}
-
-void Model01::save_primary_layer(uint8_t layer) {
-    EEPROM.write(EEPROM_LAYER_LOCATION, layer);
-}
-
-uint8_t Model01::load_primary_layer(uint8_t layer_count) {
-    uint8_t layer =  EEPROM.read(EEPROM_LAYER_LOCATION);
-    if (layer >= layer_count) {
-        return 0; // undefined positions get saved as 255
-    }
-    return 0; //  return keymap;
 }
 
 HARDWARE_IMPLEMENTATION KeyboardHardware;

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -29,9 +29,6 @@ class Model01 {
 
     boolean led_power_fault(void);
 
-    uint8_t load_primary_layer(uint8_t layer_count);
-    void save_primary_layer(uint8_t layer);
-
     keydata_t leftHandState;
     keydata_t rightHandState;
     keydata_t previousLeftHandState;


### PR DESCRIPTION
Drop the `load_primary_layer` and `save_primary_layer` methods, because `save_primary_layer` is not used anywhere, and as such, the whole thing is pointless at this time.

Furthermore, if we want to allow plugins to implement EEPROM storage, then its best if we leave the default layer save/load to the plugins too.