### PR TITLE
Moved the wdt_disable() call to the hardware plugins

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -64,6 +64,8 @@ void Model01::enable_high_power_leds(void) {
 }
 
 void Model01::setup(void) {
+    wdt_disable();
+    delay(100);
     enable_scanner_power();
 
     // Consider not doing this until 30s after keyboard


### PR DESCRIPTION
See keyboardio/Kaleidoscope#129 for a discussion why.