### PR TITLE
Add a `get_led_index` function

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -82,6 +82,10 @@ void Model01::led_set_crgb_at(byte row, byte col, cRGB color) {
     led_set_crgb_at(key_led_map[row][col], color);
 }
 
+uint8_t Model01::get_led_index(byte row, byte col) {
+    return key_led_map[row][col];
+}
+
 cRGB Model01::led_get_crgb_at(uint8_t i) {
     if(i<32) {
         return leftHand.ledData.leds[i];

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -18,6 +18,7 @@ class Model01 {
     void led_set_crgb_at(uint8_t i, cRGB crgb);
     cRGB led_get_crgb_at(uint8_t i);
     cRGB get_key_color(byte row, byte col);
+    uint8_t get_led_index(byte row, byte col);
 
     void scan_matrix(void);
     void read_matrix(void);


### PR DESCRIPTION
Given a `row`/`col` coordinate, this new function returns the index of the LED under that key. To be used with the `led_set_crgb_at(i, crgb)` function.
