### PR TITLE
Add helpers to aid in implementing key masking

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -5,6 +5,8 @@
 KeyboardioScanner Model01::leftHand(0);
 KeyboardioScanner Model01::rightHand(3);
 bool Model01::isLEDChanged = true;
+uint32_t Model01::leftHandMask;
+uint32_t Model01::rightHandMask;
 
 static constexpr uint8_t key_led_map[4][16] = {
   {3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60},
@@ -200,6 +202,44 @@ void Model01::rebootBootloader() {
 
   while (1) {} // This infinite loop ensures nothing else
   // happens before the watchdog reboots us
+}
+
+void Model01::maskKey(byte row, byte col) {
+  if (row >= ROWS || col >= COLS)
+    return;
+
+  if (col >= 8) {
+    rightHandMask |= SCANBIT(row, col - 8);
+  } else {
+    leftHandMask |= SCANBIT(row, col);
+  }
+}
+
+void Model01::unMaskKey(byte row, byte col) {
+  if (row >= ROWS || col >= COLS)
+    return;
+
+  if (col >= 8) {
+    rightHandMask &= ~(SCANBIT(row, col - 8));
+  } else {
+    leftHandMask &= ~(SCANBIT(row, col));
+  }
+}
+
+bool Model01::isKeyMasked(byte row, byte col) {
+  if (row >= ROWS || col >= COLS)
+    return false;
+
+  if (col >= 8) {
+    return rightHandMask & SCANBIT(row, col - 8);
+  } else {
+    return leftHandMask & SCANBIT(row, col);
+  }
+}
+
+void Model01::maskHeldKeys(void) {
+  rightHandMask = rightHandState.all;
+  leftHandMask = leftHandState.all;
 }
 
 HARDWARE_IMPLEMENTATION KeyboardHardware;

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -30,6 +30,15 @@ class Model01 {
 
   boolean ledPowerFault(void);
 
+  /* Key masking
+   * -----------
+   *
+   * There are situations when one wants to ignore key events for a while, and
+   * mask them out. These functions help do that. In isolation, they do nothing,
+   * plugins and the core firmware is expected to make use of these.
+   *
+   * See `handleKeyswitchEvent` in the Kaleidoscope sources for a use-case.
+   */
   void maskKey(byte row, byte col);
   void unMaskKey(byte row, byte col);
   bool isKeyMasked(byte row, byte col);

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -30,6 +30,11 @@ class Model01 {
 
   boolean ledPowerFault(void);
 
+  void maskKey(byte row, byte col);
+  void unMaskKey(byte row, byte col);
+  bool isKeyMasked(byte row, byte col);
+  void maskHeldKeys(void);
+
   keydata_t leftHandState;
   keydata_t rightHandState;
   keydata_t previousLeftHandState;
@@ -39,6 +44,9 @@ class Model01 {
   static bool isLEDChanged;
   static KeyboardioScanner leftHand;
   static KeyboardioScanner rightHand;
+
+  static uint32_t leftHandMask;
+  static uint32_t rightHandMask;
 };
 
 #define SCANBIT(row,col) ((uint32_t)1 << (row * 8 + (7 - col)))


### PR DESCRIPTION
There are situations when one wants to ignore key events for a while, and mask them out. These newly introduced functions help do that.

They are in the Hardware plugin, because this is where it is most efficient to implement the masks: the hardware library knows how many bits it needs, and how best to represent the masks. We use a 32-bit bitmap here, other keyboards may use a different size, or an entirely different approach too.

This is one part of the fix to address keyboardio/Kaleidoscope#150.
