### PR TITLE
Optimize the masking code for size

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -5,8 +5,8 @@
 KeyboardioScanner Model01::leftHand(0);
 KeyboardioScanner Model01::rightHand(3);
 bool Model01::isLEDChanged = true;
-uint8_t Model01::leftHandMask[4];
-uint8_t Model01::rightHandMask[4];
+keydata_t Model01::leftHandMask;
+keydata_t Model01::rightHandMask;
 
 static constexpr uint8_t key_led_map[4][16] = {
   {3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60},
@@ -209,9 +209,9 @@ void Model01::maskKey(byte row, byte col) {
     return;
 
   if (col >= 8) {
-    rightHandMask[row] |= 1 << (7 - (col - 8));
+    rightHandMask.rows[row] |= 1 << (7 - (col - 8));
   } else {
-    leftHandMask[row] |= 1 << (7 - col);
+    leftHandMask.rows[row] |= 1 << (7 - col);
   }
 }
 
@@ -220,9 +220,9 @@ void Model01::unMaskKey(byte row, byte col) {
     return;
 
   if (col >= 8) {
-    rightHandMask[row] &= ~(1 << (7 - (col - 8)));
+    rightHandMask.rows[row] &= ~(1 << (7 - (col - 8)));
   } else {
-    leftHandMask[row] &= ~(1 << (7 - col));
+    leftHandMask.rows[row] &= ~(1 << (7 - col));
   }
 }
 
@@ -231,15 +231,15 @@ bool Model01::isKeyMasked(byte row, byte col) {
     return false;
 
   if (col >= 8) {
-    return rightHandMask[row] & (1 << (7 - (col - 8)));
+    return rightHandMask.rows[row] & (1 << (7 - (col - 8)));
   } else {
-    return leftHandMask[row] & (1 << (7 - col));
+    return leftHandMask.rows[row] & (1 << (7 - col));
   }
 }
 
 void Model01::maskHeldKeys(void) {
-  memcpy(leftHandMask, leftHandState.rows, sizeof(leftHandMask));
-  memcpy(rightHandMask, rightHandState.rows, sizeof(rightHandMask));
+  memcpy(leftHandMask.rows, leftHandState.rows, sizeof(leftHandMask));
+  memcpy(rightHandMask.rows, rightHandState.rows, sizeof(rightHandMask));
 }
 
 HARDWARE_IMPLEMENTATION KeyboardHardware;

--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -209,9 +209,9 @@ void Model01::maskKey(byte row, byte col) {
     return;
 
   if (col >= 8) {
-    rightHandMask[row] |= 1 << (col - 8);
+    rightHandMask[row] |= 1 << (7 - (col - 8));
   } else {
-    leftHandMask[row] |= 1 << (col);
+    leftHandMask[row] |= 1 << (7 - col);
   }
 }
 
@@ -220,9 +220,9 @@ void Model01::unMaskKey(byte row, byte col) {
     return;
 
   if (col >= 8) {
-    rightHandMask[row] &= ~(1 << (col - 8));
+    rightHandMask[row] &= ~(1 << (7 - (col - 8)));
   } else {
-    leftHandMask[row] &= ~(1 << col);
+    leftHandMask[row] &= ~(1 << (7 - col));
   }
 }
 
@@ -231,21 +231,15 @@ bool Model01::isKeyMasked(byte row, byte col) {
     return false;
 
   if (col >= 8) {
-    return rightHandMask[row] & (1 << (col - 8));
+    return rightHandMask[row] & (1 << (7 - (col - 8)));
   } else {
-    return leftHandMask[row] & (1 << col);
+    return leftHandMask[row] & (1 << (7 - col));
   }
 }
 
 void Model01::maskHeldKeys(void) {
-  for (byte row = 0; row < ROWS; row++) {
-    for (byte col = 0; col < COLS / 2; col++) {
-      if (leftHandState.all & SCANBIT(row, col))
-        leftHandMask[row] |= 1 << col;
-      if (rightHandState.all & SCANBIT(row, col))
-        rightHandMask[row] |= 1 << col;
-    }
-  }
+  memcpy(leftHandMask, leftHandState.rows, sizeof(leftHandMask));
+  memcpy(rightHandMask, rightHandState.rows, sizeof(rightHandMask));
 }
 
 HARDWARE_IMPLEMENTATION KeyboardHardware;

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -54,8 +54,8 @@ class Model01 {
   static KeyboardioScanner leftHand;
   static KeyboardioScanner rightHand;
 
-  static uint32_t leftHandMask;
-  static uint32_t rightHandMask;
+  static uint8_t leftHandMask[4];
+  static uint8_t rightHandMask[4];
 };
 
 #define SCANBIT(row,col) ((uint32_t)1 << ((row) * 8 + (7 - (col))))

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -54,8 +54,8 @@ class Model01 {
   static KeyboardioScanner leftHand;
   static KeyboardioScanner rightHand;
 
-  static uint8_t leftHandMask[4];
-  static uint8_t rightHandMask[4];
+  static keydata_t leftHandMask;
+  static keydata_t rightHandMask;
 };
 
 #define SCANBIT(row,col) ((uint32_t)1 << ((row) * 8 + (7 - (col))))


### PR DESCRIPTION
Using 32-bit ints is costy, so use an array of four bytes instead, which follow the bit layout of `leftHandState`/`rightHandState`. This saves us over a hundred bytes of code, a significant amount.

`::maskKey` goes from 172 bytes to 62, and similar reductions can be seen in the other functions too.