### PR TITLE
Drop the getKeyColor function from the header

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -17,7 +17,6 @@ class Model01 {
   void setCrgbAt(byte row, byte col, cRGB color);
   void setCrgbAt(uint8_t i, cRGB crgb);
   cRGB getCrgbAt(uint8_t i);
-  cRGB getKeyColor(byte row, byte col);
   uint8_t getLedIndex(byte row, byte col);
 
   void scanMatrix(void);


### PR DESCRIPTION
It has no implementation, so lets not pretend we have it.