### PR TITLE
Update for standardized format of cRGB

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -68,12 +68,12 @@ void Model01::setCrgbAt(uint8_t i, cRGB crgb) {
     cRGB oldColor = getCrgbAt(i);
     isLEDChanged |= !(oldColor.r == crgb.r && oldColor.g == crgb.g && oldColor.b == crgb.b);
 
-    leftHand.ledData.leds[i] = crgb;
+    leftHand.ledData.leds[i] = asCBGR(crgb);
   } else if (i < 64) {
     cRGB oldColor = getCrgbAt(i);
     isLEDChanged |= !(oldColor.r == crgb.r && oldColor.g == crgb.g && oldColor.b == crgb.b);
 
-    rightHand.ledData.leds[i - 32] = crgb;
+    rightHand.ledData.leds[i - 32] = asCBGR(crgb);
   } else {
     // TODO(anyone):
     // how do we want to handle debugging assertions about crazy user
@@ -91,9 +91,9 @@ uint8_t Model01::getLedIndex(byte row, byte col) {
 
 cRGB Model01::getCrgbAt(uint8_t i) {
   if (i < 32) {
-    return leftHand.ledData.leds[i];
+    return asCRGB(leftHand.ledData.leds[i]);
   } else if (i < 64) {
-    return rightHand.ledData.leds[i - 32] ;
+    return asCRGB(rightHand.ledData.leds[i - 32]);
   } else {
     return {0, 0, 0};
   }

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -2,13 +2,12 @@
 
 #include <Arduino.h>
 
-#define HARDWARE_IMPLEMENTATION Model01
+#include "Kaleidoscope-Hardware.h"
 #include "KeyboardioScanner.h"
+#define HARDWARE_IMPLEMENTATION Model01
 
 #define COLS 16
 #define ROWS 4
-
-#define CRGB(r,g,b) (cRGB){b, g, r}
 
 class Model01 {
  public:


### PR DESCRIPTION
This is pull request # 2/4 unifying the definition of `cRGB` across hardwares.  The other three pull requests are against `keyboardio/Kaleidoscope`, `keyboardio/KeyboardioScanner`, and `shortcutgg/Kaleidoscope-Hardware-Shortcut`.  None of the four pull requests will build without the others, unfortunately.

The rationale for these pull requests is as follows.  First, a unified definition of `cRGB` is intuitive and elegant.  As part of the core hardware API, it also makes sense to define `cRGB` in the Kaleidoscope core.  

Second, this brings down a major barrier to implementing an actual abstract hardware base class (which is planned as a followup series of pull requests against these same repos; however, the issue of unifying `cRGB` seemed separate enough to warrant separate pull requests with their own discussion).  In fact, the unified definition of `cRGB` is declared by itself in a file called “Kaleidoscope-Hardware.h”, which is very forward-looking as eventually it will simply be declared as part of the abstract hardware base class.

Third, although it may seem at first glance that these pull requests may harm performance in terms of code size and/or execution time, this is actually not the case.  The additional function calls are inlined, and the resulting code generally just takes struct-copy operations that were already happening and changes them to copy struct members to different places.  The code is more verbose, but should compile down to the same number of operations to my knowledge.  To back up these assertions, we compare results of compiling a few sketches before and after these four pull requests are applied.  For the Model 01, we build the two sketches in `keyboardio/Kaleidoscope/examples`; the unified `cRGB` definition results in the exact same code size for `AppSwitcher`, and actually a 2-byte *improvement* for `Kaleidoscope`.  For the Shortcut, we build the sketch in `shortcutgg/Kaleidoscope-Hardware-Shortcut/examples`; again we end up with the exact same code size with or without these four pull requests.  I would imagine these results also indicate execution time hasn’t changed.