### PR TITLE
Subtle change to key masking computation

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -212,14 +212,20 @@ void Model01::rebootBootloader() {
 // shift a bit starting from the left (B10000000, or 128) by that many places to get
 // there. This is all nice and convenient because the keyboard has 64 keys, in symmetric
 // halves, with eight keys per logical row.
+
+constexpr byte HIGH_BIT = B10000000;
+constexpr byte HAND_BIT = B00001000;
+constexpr byte ROW_BITS = B00110000;
+constexpr byte COL_BITS = B00000111;
+
 void Model01::maskKey(byte row, byte col) {
   if (row >= ROWS || col >= COLS)
     return;
 
-  if (col & 8) {
-    rightHandMask.rows[row] |= (128 >> (col & 7));
+  if (col & HAND_BIT) {
+    rightHandMask.rows[row] |= (HIGH_BIT >> (col & COL_BITS));
   } else {
-    leftHandMask.rows[row] |= (128 >> (col & 7));
+    leftHandMask.rows[row] |= (HIGH_BIT >> (col & COL_BITS));
   }
 }
 
@@ -227,10 +233,10 @@ void Model01::unMaskKey(byte row, byte col) {
   if (row >= ROWS || col >= COLS)
     return;
 
-  if (col & 8) {
-    rightHandMask.rows[row] &= ~(128 >> (col & 7));
+  if (col & HAND_BIT) {
+    rightHandMask.rows[row] &= ~(HIGH_BIT >> (col & COL_BITS));
   } else {
-    leftHandMask.rows[row] &= ~(128 >> (col & 7));
+    leftHandMask.rows[row] &= ~(HIGH_BIT >> (col & COL_BITS));
   }
 }
 
@@ -238,10 +244,10 @@ bool Model01::isKeyMasked(byte row, byte col) {
   if (row >= ROWS || col >= COLS)
     return false;
 
-  if (col & 8) {
-    return rightHandMask.rows[row] & (128 >> (col & 7));
+  if (col & HAND_BIT) {
+    return rightHandMask.rows[row] & (HIGH_BIT >> (col & COL_BITS));
   } else {
-    return leftHandMask.rows[row] & (128 >> (col & 7));
+    return leftHandMask.rows[row] & (HIGH_BIT >> (col & COL_BITS));
   }
 }
 

--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -204,14 +204,22 @@ void Model01::rebootBootloader() {
   // happens before the watchdog reboots us
 }
 
+// In the maskKey(), unMaskKey(), and isKeyMasked() functions, we read and write bits in
+// two bitfields -- one for each half of the keyboard. The fourth bit of the column number
+// tells us which bitfield (right or left) to access, thus the "8" (B00001000). The row
+// number tells us which element of the array to access. The last three bits of the column
+// number tell us which of the eight bits to access, thus the "7" (B00000111), and we
+// shift a bit starting from the left (B10000000, or 128) by that many places to get
+// there. This is all nice and convenient because the keyboard has 64 keys, in symmetric
+// halves, with eight keys per logical row.
 void Model01::maskKey(byte row, byte col) {
   if (row >= ROWS || col >= COLS)
     return;
 
-  if (col >= 8) {
-    rightHandMask.rows[row] |= 1 << (7 - (col - 8));
+  if (col & 8) {
+    rightHandMask.rows[row] |= (128 >> (col & 7));
   } else {
-    leftHandMask.rows[row] |= 1 << (7 - col);
+    leftHandMask.rows[row] |= (128 >> (col & 7));
   }
 }
 
@@ -219,10 +227,10 @@ void Model01::unMaskKey(byte row, byte col) {
   if (row >= ROWS || col >= COLS)
     return;
 
-  if (col >= 8) {
-    rightHandMask.rows[row] &= ~(1 << (7 - (col - 8)));
+  if (col & 8) {
+    rightHandMask.rows[row] &= ~(128 >> (col & 7));
   } else {
-    leftHandMask.rows[row] &= ~(1 << (7 - col));
+    leftHandMask.rows[row] &= ~(128 >> (col & 7));
   }
 }
 
@@ -230,10 +238,10 @@ bool Model01::isKeyMasked(byte row, byte col) {
   if (row >= ROWS || col >= COLS)
     return false;
 
-  if (col >= 8) {
-    return rightHandMask.rows[row] & (1 << (7 - (col - 8)));
+  if (col & 8) {
+    return rightHandMask.rows[row] & (128 >> (col & 7));
   } else {
-    return leftHandMask.rows[row] & (1 << (7 - col));
+    return leftHandMask.rows[row] & (128 >> (col & 7));
   }
 }
 


### PR DESCRIPTION
This doesn't change behaviour at all; it's just a different way to do the computation, which I think is much clearer. I also added an explanatory comment.

* It's now all bitwise operations, without arithmetic thrown in.
* It uses the same exact formula for finding bits on both sides of the keyboard.
* It saves 14 bytes in program memory (on the default Model01-Firmware: 18994 vs 19008 bytes).