### PR TITLE
Pull in the KeyboardioHID HIDAdaptor library

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 
 #define HARDWARE_IMPLEMENTATION Model01
+#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 #include "KeyboardioScanner.h"
 
 #define COLS 16


### PR DESCRIPTION
Instead of pulling it in from the user sketch, do so from the hardware plugin. The hardware and the adaptor are in close relationship anyway, and with tweakable knobs, we do not need to use a different adaptor library in advanced cases, either.