### PR TITLE
Further actOnMatrixScan optimizations

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -164,24 +164,22 @@ void Model01::actOnHalfRow(byte row, byte colState, byte colPrevState, byte star
     }
   } else {
     for (byte col = 0; col < 8; col++) {
-      uint8_t keyState = (bitRead(colPrevState, col) << 0) |
-                         (bitRead(colState, col) << 1);
+      // Build up the key state for row, col
+      uint8_t keyState = ((bitRead(colPrevState, 0) << 0) |
+                          (bitRead(colState,     0) << 1));
       handleKeyswitchEvent(Key_NoKey, row, startPos - col, keyState);
+
+      // Throw away the data we've just used, so we can read the next column
+      colState = colState >> 1;
+      colPrevState = colPrevState >> 1;
     }
   }
 }
 
 void Model01::actOnMatrixScan() {
   for (byte row = 0; row < 4; row++) {
-    uint8_t colState = leftHandState.rows[row];
-    uint8_t colPrevState = previousLeftHandState.rows[row];
-
-    actOnHalfRow(row, colState, colPrevState, 7);
-
-    colState = rightHandState.rows[row];
-    colPrevState = previousRightHandState.rows[row];
-
-    actOnHalfRow(row, colState, colPrevState, 15);
+    actOnHalfRow(row, leftHandState.rows[row], previousLeftHandState.rows[row], 7);
+    actOnHalfRow(row, rightHandState.rows[row], previousRightHandState.rows[row], 15);
   }
 }
 


### PR DESCRIPTION
In `actOnMatrixScan`, there is no need to use temporary variables, we can just pass the data directly to `actOnHalfRow`, and doing so makes the code easier to follow.

In `actOnHalfRow`, we can further optimize things if instead of reading the Nth bit, we always read the first, and shift the byte at the end.

All of these optimizations were done by @obra, I just wrote the commit message.