### PR TITLE
actOnHalfRow: Do not handle events on fully idle positions

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -158,16 +158,13 @@ void Model01::readMatrix() {
 }
 
 void Model01::actOnHalfRow(byte row, byte colState, byte colPrevState, byte startPos) {
-  if ((colState == colPrevState) && (colState == 0)) {
-    for (byte col = 0; col < 8; col++) {
-      handleKeyswitchEvent(Key_NoKey, row, startPos - col, 0);
-    }
-  } else {
+  if ((colState != colPrevState) || (colState != 0)) {
     for (byte col = 0; col < 8; col++) {
       // Build up the key state for row, col
       uint8_t keyState = ((bitRead(colPrevState, 0) << 0) |
                           (bitRead(colState,     0) << 1));
-      handleKeyswitchEvent(Key_NoKey, row, startPos - col, keyState);
+      if (keyState)
+        handleKeyswitchEvent(Key_NoKey, row, startPos - col, keyState);
 
       // Throw away the data we've just used, so we can read the next column
       colState = colState >> 1;


### PR DESCRIPTION
When a keyswitch has been off in the previous cycle and is still off now, do not call `handleKeyswitchEvent` on it. As an extension, when the whole column is idle, skip the whole thing.

In practice, handling fully idle keys is not useful. There are many plugins which explicitly look for this case and return early, because it isn't an interesting event. As such, not calling the event handler in this case makes sense, as we save not only a few needless checks in plugins, but our performance improves greatly too.

There is only one case I could find where we **do** use the fact that even idle events go through the event handlers: macros. One can create a macro that toggles on keypress, and remains active after release too. This works because the handlers get called for idle keys too. If we do not do that, this use-case will break. One can still create such macros, but will have to use a loop hook in addition. I'd argue that using a loop hook is the better way anyway. But, this is a breaking change nevertheless.

(Built on top of #22 for now.)