### PR TITLE
Implement a way to detach from / attach to the host

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -251,4 +251,12 @@ void Model01::setKeyscanInterval(uint8_t interval) {
   rightHand.setKeyscanInterval(interval);
 }
 
+void Model01::detachFromHost() {
+  UDCON |= (1 << DETACH);
+}
+
+void Model01::attachToHost() {
+  UDCON &= ~(1 << DETACH);
+}
+
 HARDWARE_IMPLEMENTATION KeyboardHardware;

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -29,6 +29,17 @@ class Model01 {
   void rebootBootloader();
 
 
+  /** Detaching from / attaching to the host.
+   *
+   * These two functions should detach the device from (or attach it to) the
+   * host, preferably without rebooting the device. Their purpose is to allow
+   * one to do some configuration inbetween, so the re-attach happens with
+   * different properties. The device remains powered between these operations,
+   * only the connection to the host gets severed.
+   */
+  void detachFromHost();
+  void attachToHost();
+
   /* These public functions are things supported by the Model 01, but
    * aren't necessarily part of the Kaleidoscope API
    */


### PR DESCRIPTION
These functions can be used to detach from the host, then re-attach, possibly with different properties, without having to reboot the device.