### PR TITLE
Better keyswitch state APIs

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -259,17 +259,27 @@ void Model01::attachToHost() {
   UDCON &= ~(1 << DETACH);
 }
 
-uint8_t Model01::getKeyswitchStateAtPosition(byte row, byte col) {
+bool Model01::isKeyswitchPressed(byte row, byte col) {
   if (col <= 7) {
-    return bitRead(leftHandState.rows[row], 7 - col);
+    return (bitRead(leftHandState.rows[row], 7 - col) != 0);
   } else {
-    return bitRead(rightHandState.rows[row], 7 - (col - 8));
+    return (bitRead(rightHandState.rows[row], 7 - (col - 8)) != 0);
   }
 }
 
-uint8_t Model01::getKeyswitchStateAtPosition(uint8_t keyIndex) {
+bool Model01::isKeyswitchPressed(uint8_t keyIndex) {
   keyIndex--;
-  return getKeyswitchStateAtPosition(keyIndex / COLS, keyIndex % COLS);
+  return isKeyswitchPressed(keyIndex / COLS, keyIndex % COLS);
+}
+
+uint8_t Model01::pressedKeyswitchCount() {
+  uint8_t count = 0;
+
+  for (uint8_t i = 0; i < 32; i++) {
+    count += bitRead(leftHandState.all, i) + bitRead(rightHandState.all, i);
+  }
+
+  return count;
 }
 
 HARDWARE_IMPLEMENTATION KeyboardHardware;

--- a/src/Kaleidoscope-Hardware-Model01.h
+++ b/src/Kaleidoscope-Hardware-Model01.h
@@ -62,17 +62,38 @@ class Model01 {
   bool isKeyMasked(byte row, byte col);
   void maskHeldKeys(void);
 
-  /** Key switch state
+  /** Key switch states
    *
-   * These two methods return the state of the keyswitch at any given position,
-   * regardless of which half they are on. This is a hardware-agnostic access to
-   * the key switch states.
-   *
-   * The first variant requires a row and a column, the second an index, as
-   * returned by `keyIndex`.
+   * These methods offer a way to peek at the key switch states, for those cases
+   * where we need to deal with the state closest to the hardware. Some methods
+   * offer a way to check if a key is pressed, others return the number of
+   * pressed keys.
    */
-  uint8_t getKeyswitchStateAtPosition(byte row, byte col);
-  uint8_t getKeyswitchStateAtPosition(uint8_t keyIndex);
+  /**
+   * Check if a key is pressed at a given position.
+   *
+   * @param row is the row the key is located at in the matrix.
+   * @param col is the column the key is located at in the matrix.
+   *
+   * @returns true if the key is pressed, false otherwise.
+   */
+  bool isKeyswitchPressed(byte row, byte col);
+  /**
+   * Check if a key is pressed at a given position.
+   *
+   * @param keyIndex is the key index, as calculated by `keyIndex`.
+   *
+   * @note Key indexes start at 1, not 0!
+   *
+   * @returns true if the key is pressed, false otherwise.
+   */
+  bool isKeyswitchPressed(uint8_t keyIndex);
+  /**
+   * Check the number of key switches currently pressed.
+   *
+   * @returns the number of keys pressed.
+   */
+  uint8_t pressedKeyswitchCount();
 
   keydata_t leftHandState;
   keydata_t rightHandState;


### PR DESCRIPTION
Instead of `getKeyswitchStateAtPosition`, which is long, unintuitive and feels wrong too, introduce `isKeyswitchPressed`, shorter, better, more reasonable (because it returns a bool - we support only two states anyway!).

Additionally, add `pressedKeyswitchCount()`, which returns the number of key switches pressed.
