### PR TITLE
Use __builtin_popcountl() in pressedKeyswitchCount()

### DIFF
--- a/src/Kaleidoscope-Hardware-Model01.cpp
+++ b/src/Kaleidoscope-Hardware-Model01.cpp
@@ -273,13 +273,7 @@ bool Model01::isKeyswitchPressed(uint8_t keyIndex) {
 }
 
 uint8_t Model01::pressedKeyswitchCount() {
-  uint8_t count = 0;
-
-  for (uint8_t i = 0; i < 32; i++) {
-    count += bitRead(leftHandState.all, i) + bitRead(rightHandState.all, i);
-  }
-
-  return count;
+  return __builtin_popcountl(leftHandState.all) + __builtin_popcountl(rightHandState.all);
 }
 
 HARDWARE_IMPLEMENTATION KeyboardHardware;


### PR DESCRIPTION
Instead of iterating through all the bits, use `__builtin_popcountl()`, provided by gcc, which should be considerably more efficient.

Fixes #27.